### PR TITLE
fix: ignore pre_saves for loaddata 

### DIFF
--- a/juntagrico_assignment_request/hack.py
+++ b/juntagrico_assignment_request/hack.py
@@ -38,9 +38,10 @@ def pre_save_assignment(sender, instance, **kwds):
     """
     If assignment comes from request, change back values as before saving it
     """
-    if hasattr(instance, 'assignmentrequest'):
-        ar = instance.assignmentrequest
-        instance.member = ar.member
-        instance.amount = ar.get_amount()
-        instance.job = ar.get_matching_job()
-        print(f'restored {instance} using {ar}')
+    if not kwds.get('raw', False):
+        if hasattr(instance, 'assignmentrequest'):
+            ar = instance.assignmentrequest
+            instance.member = ar.member
+            instance.amount = ar.get_amount()
+            instance.job = ar.get_matching_job()
+            print(f'restored {instance} using {ar}')

--- a/juntagrico_assignment_request/models.py
+++ b/juntagrico_assignment_request/models.py
@@ -111,10 +111,11 @@ class AssignmentRequest(models.Model):
         """
         Callback before saving assignment request
         """
-        if instance.status == cls.CONFIRMED:
-            cls._create_or_update_assignment(instance)
-        else:
-            instance.assignment = None  # assignment object will be deleted after saving
+        if not kwds.get('raw', False):
+            if instance.status == cls.CONFIRMED:
+                cls._create_or_update_assignment(instance)
+            else:
+                instance.assignment = None  # assignment object will be deleted after saving
 
     def set_activityarea_if_none(self):
         # create/use default activity_area if none specified


### PR DESCRIPTION
when using manage.py loaddata the presave signals are triggered but the actions should usually be ignored to avoid accessing objects that don't exist yet.